### PR TITLE
Fix iteration over ink variable map

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -89,7 +89,10 @@ export const Preview: React.FC<PreviewProps> = ({ filePath }) => {
       const variables: Record<string, any> = {};
       const globalVars = (story as any).variablesState;
       if (globalVars && globalVars._globalVariables) {
-        for (const [key, value] of globalVars._globalVariables) {
+        const iterable = typeof globalVars._globalVariables.entries === 'function'
+          ? Array.from(globalVars._globalVariables.entries())
+          : Object.entries(globalVars._globalVariables as Record<string, any>);
+        for (const [key, value] of iterable) {
           variables[key] = value;
         }
       }


### PR DESCRIPTION
## Summary
- handle object-based global variables in Preview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688854862564832c933f8c2f013fc476