### PR TITLE
Add AI chat sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ npm run lint
 
 ---
 
+## 🤖 AI 对话模块
+
+* 左侧 ActivityBar 新增 **Bot** 选项，点击后在侧边栏打开 AI 聊天面板
+* 面板顶部可填写自定义 API 地址，发送消息时将以 `{ message, context }` POST 请求
+* 未填写时默认回显输入内容，可用于离线体验
+
+---
+
 ## 📚 参考链接
 
 * [inkjs](https://github.com/y-lohse/inkjs)：Ink 运行时

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,11 @@ import { Editor } from './components/Editor';
 import { Preview } from './components/Preview';
 import { NodeGraph } from './components/NodeGraph';
 import { PluginHost } from './components/PluginHost';
+import AIChatPanel from './components/ai/AIChatPanel';
 import type { SidebarTab } from './types/sidebar';
 
 const AppContent: React.FC = () => {
-  const { plugins, activeFile, selectFile, openProject } = useContext(ProjectContext)!;
+  const { plugins, activeFile, selectFile, openProject, projectPath } = useContext(ProjectContext)!;
   const [view, setView] = useState<'preview' | 'graph'>('preview');
   const [activeTab, setActiveTab] = useState<SidebarTab>('explorer');
   const [pluginCtx, setPluginCtx] = useState<{
@@ -30,6 +31,14 @@ const AppContent: React.FC = () => {
 
       {/* 侧边栏 */}
       {activeTab === 'explorer' && <ProjectExplorer onSelect={selectFile} />}
+      {activeTab === 'bot' && (
+        <AIChatPanel
+          projectContext={{
+            currentFile: activeFile,
+            projectName: projectPath ? projectPath.split(/[/\\]/).pop() : '',
+          }}
+        />
+      )}
 
       {/* 右侧：主区域 */}
       <div className="flex-1 flex flex-col">

--- a/src/components/ai/AIChatPanel.tsx
+++ b/src/components/ai/AIChatPanel.tsx
@@ -1,0 +1,139 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Bot, Send, Settings } from 'lucide-react';
+import AIMessage, { AIMessageData } from './AIMessage';
+import QuickActions from './QuickActions';
+
+interface AIChatPanelProps {
+  projectContext: { currentFile: string | null; projectName?: string | null };
+  apiUrl?: string;
+}
+
+export const AIChatPanel: React.FC<AIChatPanelProps> = ({
+  projectContext,
+  apiUrl: initialApiUrl = '',
+}) => {
+  const [messages, setMessages] = useState<AIMessageData[]>([]);
+  const [input, setInput] = useState('');
+  const [isThinking, setIsThinking] = useState(false);
+  const [apiUrl, setApiUrl] = useState(initialApiUrl);
+  const [showApiConfig, setShowApiConfig] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMsg: AIMessageData = {
+      id: Date.now(),
+      type: 'user',
+      content: input,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setIsThinking(true);
+
+    let reply = '';
+    if (apiUrl) {
+      try {
+        const res = await fetch(apiUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: input, context: projectContext }),
+        });
+        const data = await res.json();
+        reply = data.reply ?? data.response ?? '';
+      } catch {
+        reply = '自定义 API 调用失败';
+      }
+    } else {
+      reply = `你说: ${input}`;
+    }
+
+    const aiMsg: AIMessageData = {
+      id: Date.now() + 1,
+      type: 'ai',
+      content: reply,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, aiMsg]);
+    setIsThinking(false);
+  };
+
+  return (
+    <div
+      className="w-64 flex flex-col"
+      style={{
+        backgroundColor: 'var(--color-sidebarBackground)',
+        borderRight: `1px solid var(--color-sidebarBorder)`,
+      }}
+    >
+      <div
+        className="flex items-center justify-between px-3 py-2 border-b"
+        style={{ borderColor: 'var(--color-sidebarBorder)' }}
+      >
+        <div className="flex items-center gap-2 text-sm">
+          <Bot size={16} />
+          <span>AI 聊天</span>
+        </div>
+        <button
+          onClick={() => setShowApiConfig((v) => !v)}
+          className="text-gray-400 hover:text-white"
+        >
+          <Settings size={14} />
+        </button>
+      </div>
+      {showApiConfig && (
+        <div className="p-2 border-b" style={{ borderColor: 'var(--color-sidebarBorder)' }}>
+          <input
+            className="w-full text-xs p-1 rounded border"
+            style={{
+              backgroundColor: 'var(--color-inputBackground)',
+              borderColor: 'var(--color-border)',
+              color: 'var(--color-textPrimary)',
+            }}
+            placeholder="自定义 API 地址"
+            value={apiUrl}
+            onChange={(e) => setApiUrl(e.target.value)}
+          />
+        </div>
+      )}
+      <div className="flex-1 overflow-y-auto p-3 space-y-3">
+        {messages.map((m) => (
+          <AIMessage key={m.id} message={m} />
+        ))}
+        {isThinking && <div className="text-xs text-gray-400">AI...</div>}
+        <div ref={endRef} />
+      </div>
+      <div className="p-3 border-t" style={{ borderColor: 'var(--color-sidebarBorder)' }}>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            className="flex-1 text-sm px-2 py-1 rounded border"
+            style={{
+              backgroundColor: 'var(--color-inputBackground)',
+              borderColor: 'var(--color-border)',
+              color: 'var(--color-textPrimary)',
+            }}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+            placeholder="向 AI 提问..."
+          />
+          <button
+            onClick={sendMessage}
+            disabled={!input.trim()}
+            className="p-2 bg-purple-600 text-white rounded disabled:opacity-50"
+          >
+            <Send size={16} />
+          </button>
+        </div>
+        <QuickActions onAction={(t) => setInput(t)} />
+      </div>
+    </div>
+  );
+};
+
+export default AIChatPanel;

--- a/src/components/ai/AIMessage.tsx
+++ b/src/components/ai/AIMessage.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export interface AIMessageData {
+  id: number;
+  type: 'ai' | 'user';
+  content: string;
+  timestamp: Date;
+}
+
+interface AIMessageProps {
+  message: AIMessageData;
+}
+
+const formatTime = (date: Date) =>
+  date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
+
+export const AIMessage: React.FC<AIMessageProps> = ({ message }) => {
+  const isAI = message.type === 'ai';
+  return (
+    <div className={`text-sm ${isAI ? 'text-left' : 'text-right'}`}>
+      <div
+        className={`rounded px-3 py-2 inline-block whitespace-pre-wrap ${
+          isAI ? 'bg-gray-700 text-gray-100' : 'bg-blue-600 text-white'
+        }`}
+      >
+        {message.content}
+      </div>
+      <div className="text-xs text-gray-400 mt-1">
+        {formatTime(message.timestamp)}
+      </div>
+    </div>
+  );
+};
+
+export default AIMessage;

--- a/src/components/ai/QuickActions.tsx
+++ b/src/components/ai/QuickActions.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface QuickActionsProps {
+  onAction: (text: string) => void;
+}
+
+const actions = ['生成角色', '优化代码', '剧情转折'];
+
+export const QuickActions: React.FC<QuickActionsProps> = ({ onAction }) => (
+  <div className="mt-2 flex flex-wrap gap-2">
+    {actions.map((a) => (
+      <button
+        key={a}
+        onClick={() => onAction(a)}
+        className="text-xs px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+      >
+        {a}
+      </button>
+    ))}
+  </div>
+);
+
+export default QuickActions;


### PR DESCRIPTION
## Summary
- create AI chat components under `src/components/ai`
- hook AIChatPanel into sidebar when the **Bot** tab is active
- allow custom API endpoint and provide quick actions
- document new feature in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6887ceb21be8832c94ed5b09499f7f30