### PR TITLE
fix: open model settings from chat

### DIFF
--- a/src/components/ai/AIChatPanel.tsx
+++ b/src/components/ai/AIChatPanel.tsx
@@ -151,6 +151,10 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
   
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
+  const handleToggleSettings = () => {
+    setShowModelConfig(true);
+  };
+
   // 获取当前选中的模型配置
   const getCurrentModel = (): AIModelConfig | undefined => {
     if (!selectedModelId) return undefined;
@@ -644,10 +648,15 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
       {/* 消息列表 */}
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.map((message) => (
-          <AIMessage key={message.id} message={message} />
+          <AIMessage key={message.id} message={message} onToggleSettings={handleToggleSettings} />
         ))}
-        
-        {isAiThinking && <AIMessage message={{ id: 0, type: 'ai' as const, content: '', timestamp: new Date() }} />}
+
+        {isAiThinking && (
+          <AIMessage
+            message={{ id: 0, type: 'ai' as const, content: '', timestamp: new Date() }}
+            onToggleSettings={handleToggleSettings}
+          />
+        )}
         <div ref={messagesEndRef} />
       </div>
 

--- a/src/components/ai/AIMessage.tsx
+++ b/src/components/ai/AIMessage.tsx
@@ -23,6 +23,7 @@ export interface AIMessageData {
 
 interface AIMessageProps {
   message: AIMessageData;
+  onToggleSettings?: () => void;
 }
 
 const formatTime = (date: Date) => {
@@ -97,7 +98,7 @@ const AIThinkingIndicator = () => (
   </div>
 );
 
-export const AIMessage: React.FC<AIMessageProps> = ({ message }) => {
+export const AIMessage: React.FC<AIMessageProps> = ({ message, onToggleSettings }) => {
   const [copiedCode, setCopiedCode] = useState<number | null>(null);
   const isAI = message.type === 'ai';
   const isUser = message.type === 'user';
@@ -160,7 +161,10 @@ export const AIMessage: React.FC<AIMessageProps> = ({ message }) => {
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
       {isAI && (
-        <div className="w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center flex-shrink-0 mr-3">
+        <div
+          className="w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center flex-shrink-0 mr-3 cursor-pointer"
+          onClick={onToggleSettings}
+        >
           <Bot size={16} className="text-white" />
         </div>
       )}


### PR DESCRIPTION
## Summary
- allow clicking the AI avatar in chat to open the model configuration panel
- wire message clicks to existing model config state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688b1291e764832c8c46813c6570c8b1