### PR TITLE
fix: recover monaco model for marker setting

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -158,9 +158,17 @@ export const Editor: React.FC<EditorProps> = ({ filePath, goToLine }) => {
         const markers: Marker[] = await lintInk(val, currentFilePath);
         console.log('Editor: Received markers from lintInk:', markers.length, markers);
         
-        const model = editorRef.current.getModel();
+        let model = editorRef.current.getModel();
+        if (!model && monacoRef.current) {
+          const models = monacoRef.current.editor.getModels();
+          if (models.length > 0) {
+            model = models[0];
+            editorRef.current.setModel(model);
+            console.log('Editor: Recovered missing model from Monaco models list');
+          }
+        }
         if (!model) {
-          console.error('Editor: No model available for setting markers');
+          console.error('Editor: No model available for setting markers after attempt to recover');
           return;
         }
         


### PR DESCRIPTION
## Summary
- recover Monaco editor model if missing before setting markers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688b16a56f44832c95ba500cc0f2aeb9