### PR TITLE
feat: make sidebar and panes resizable

### DIFF
--- a/src/components/ProjectExplorer/index.tsx
+++ b/src/components/ProjectExplorer/index.tsx
@@ -26,10 +26,9 @@ export const ProjectExplorer: React.FC<ProjectExplorerProps> = ({ onSelect }) =>
 
   return (
     <div
-      className="w-64 flex flex-col"
+      className="flex flex-col h-full w-full"
       style={{
         backgroundColor: 'var(--color-sidebarBackground)',
-        borderRight: `1px solid var(--color-sidebarBorder)`,
         color: 'var(--color-sidebarForeground)'
       }}
     >

--- a/src/components/ai/AIChatPanel.tsx
+++ b/src/components/ai/AIChatPanel.tsx
@@ -439,7 +439,7 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="w-96 bg-gray-800 border-l border-gray-700 flex flex-col h-full">
+    <div className="bg-gray-800 flex flex-col h-full w-full">
       {/* 面板头部 */}
       <div className="p-4 border-b border-gray-700 flex items-center justify-between">
         <div className="flex items-center space-x-3">

--- a/src/hooks/useWorkspaceState.ts
+++ b/src/hooks/useWorkspaceState.ts
@@ -35,6 +35,8 @@ interface UseWorkspaceStateProps {
   view: 'preview' | 'graph';
   activeTab: 'explorer' | 'search' | 'git' | 'bot' | 'settings';
   sidebarVisible: boolean;
+  sidebarWidth?: number;
+  editorWidth?: number;
 }
 
 export const useWorkspaceState = ({
@@ -42,7 +44,9 @@ export const useWorkspaceState = ({
   activeFile,
   view,
   activeTab,
-  sidebarVisible
+  sidebarVisible,
+  sidebarWidth,
+  editorWidth
 }: UseWorkspaceStateProps) => {
   
   // 持续保存工作区状态
@@ -72,10 +76,12 @@ export const useWorkspaceState = ({
     const uiState: UIState = {
       view,
       activeTab,
-      sidebarVisible
+      sidebarVisible,
+      sidebarWidth,
+      editorWidth
     };
     crashRecovery.saveUIState(uiState);
-  }, [view, activeTab, sidebarVisible]);
+  }, [view, activeTab, sidebarVisible, sidebarWidth, editorWidth]);
 
   // 恢复状态
   const restoreStates = useCallback(() => {


### PR DESCRIPTION
## Summary
- add sidebarWidth/editorWidth state and drag handles for resizing
- persist sidebar and editor widths in workspace state
- remove fixed widths from ProjectExplorer and AIChatPanel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; install attempt returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_688b1b936c60832cb7247938de4b1de8